### PR TITLE
Update patrolV2.mzn

### DIFF
--- a/functions/patrol/patrolV2.mzn
+++ b/functions/patrol/patrolV2.mzn
@@ -1,5 +1,4 @@
 % Patrol Scheduling
-include "globals.mzn";
 
 enum SOLDIER;
 enum SHIFT = { OFF, EVE, NIGHT };
@@ -13,13 +12,15 @@ int: u;
 
 array[SOLDIER, DAY] of var SHIFT: roster;
 
-constraint forall (d in 1..(nDays-1), s in SOLDIER) ((roster[s, d] = EVE) -> (roster[s, d+1] != NIGHT));
-constraint forall (d in 1..(nDays-2), s in SOLDIER) ((roster[s, d] = NIGHT) /\ (roster[s, d+1] = NIGHT) -> (roster[s, d+2] != NIGHT));
+constraint forall (d in 1..(nDays-2), s in SOLDIER) ((roster[s,d] = NIGHT) /\ (roster[s,d+1] = NIGHT) -> (roster[s,d+2] != NIGHT));
+constraint forall (d in 1..(nDays-1), s in SOLDIER) ((roster[s,d] = EVE) -> (roster[s,d+1] != NIGHT));
 
-constraint forall (d in DAY) (sum (s in SOLDIER) ((roster[s, d] = NIGHT)) = o);
+constraint forall (d in DAY) (sum (s in SOLDIER) ((roster[s,d] = NIGHT)) = o);
 array[DAY] of var l..u: onEve;
 constraint onEve = [sum (s in SOLDIER) (roster[s,d]=EVE) | d in DAY];
 
 solve maximize sum(onEve);
 
-output ["Soldier "++show(s)++" on Day "++show(d)++" takes the "++show(roster[s,d])++" shift\n" ++ if s == max(SOLDIER) then show(onEve[d])++"\n" else "" endif | d in DAY, s in SOLDIER]++[show(sum(onEve))];
+output ["Soldier \(s) on Day \(d) takes the \(roster[s,d]) shift\n" 
+        ++ if s == max(SOLDIER) then "\(onEve[d])\n" else "" endif | d in DAY, s in SOLDIER]
+        ++[show(sum(onEve))];


### PR DESCRIPTION
This version included "globals.mzn" which is actually only needed in patrolV3.mzn. Removed for clarity.

Also:

reformatted the constraints so that they look exactly as in patrolV1, no changes.
Shortened the long output command.

Interesting:

If the constraint about "not three night shifts" comes before the constraint "evening then not night" (in this change request), then a solution is found in 13s (on my machine).
If the constraint about "evening then not night" comes before the constraint "not three night shifts" (originally), then a solution is found in 33s (on my machine).