### PR TITLE
Update patrolV3.mzn

### DIFF
--- a/functions/patrol/patrolV3.mzn
+++ b/functions/patrol/patrolV3.mzn
@@ -13,13 +13,14 @@ int: u;
 
 array[SOLDIER, DAY] of var SHIFT: roster;
 
-constraint forall (d in 1..(nDays-1), s in SOLDIER) ((roster[s, d] = EVE) -> (roster[s, d+1] != NIGHT));
-constraint forall (d in 1..(nDays-2), s in SOLDIER) 
-   ((roster[s, d] = NIGHT) /\ (roster[s, d+1] = NIGHT) -> (roster[s, d+2] != NIGHT));
+constraint forall (d in 1..(nDays-2), s in SOLDIER) ((roster[s,d] = NIGHT) /\ (roster[s,d+1] = NIGHT) -> (roster[s,d+2] != NIGHT));
+constraint forall (d in 1..(nDays-1), s in SOLDIER) ((roster[s,d] = EVE) -> (roster[s,d+1] != NIGHT));
 
 array[DAY] of var l..u: onEve;
-constraint forall(d in DAY)(global_cardinality([roster[s,d] | s in SOLDIER], [NIGHT, EVE], [o, onEve[d]]));
+constraint forall (d in DAY) (global_cardinality([roster[s,d] | s in SOLDIER], [NIGHT, EVE], [o, onEve[d]]));
 
 solve maximize sum(onEve);
 
-output ["Soldier "++show(s)++" on Day "++show(d)++" takes the "++show(roster[s,d])++" shift\n" ++ if s == max(SOLDIER) then show(onEve[d])++"\n" else "" endif | d in DAY, s in SOLDIER]++[show(sum(onEve))];
+
+output ["Soldier \(s) on Day \(d) takes the \(roster[s,d]) shift\n" 
+        ++ if s == max(SOLDIER) then "\(onEve[d])\n" else "" endif | d in DAY, s in SOLDIER]++[show(sum(onEve))];


### PR DESCRIPTION
Constraints now appear in same order as for PatrolV1 (running this no changes in time-to-solution apparent if the order is changed) 

As for the other patrolX.mzn, output line has been shortened.