### PR TITLE
Changed variable name

### DIFF
--- a/scheduling/basic/basic_sched.mzn
+++ b/scheduling/basic/basic_sched.mzn
@@ -15,7 +15,7 @@ constraint forall(i in PREC)
 %)
 ;
 
-var 0..t: makespan = max(t in TASK)(start[t] + duration[t]);
+var 0..t: makespan = max(task in TASK)(start[task] + duration[task]);
 solve minimize makespan;
 
 output [show(makespan)," = ", show(start)];


### PR DESCRIPTION
Changing the variable name avoids a "shadowing" variable of "t" (the task) shadowing "t" (the sum(duraction))